### PR TITLE
fix: abort token push when fetching existing tokens fails

### DIFF
--- a/DrissionPage_example.py
+++ b/DrissionPage_example.py
@@ -1117,9 +1117,11 @@ def push_sso_to_api(new_tokens: list):
                 tokens_to_push = deduped
                 print(f"[*] 查询到线上 {len(existing_tokens)} 个 token，合并本次 {len(new_tokens)} 个，共 {len(deduped)} 个")
             else:
-                print(f"[Warn] 查询线上 token 失败: HTTP {get_resp.status_code}，仅推送本次 token")
+                print(f"[Error] 查询线上 token 失败: HTTP {get_resp.status_code}，放弃推送以保护存量数据")
+                return
         except Exception as e:
-            print(f"[Warn] 查询线上 token 异常: {e}，仅推送本次 token")
+            print(f"[Error] 查询线上 token 异常: {e}，放弃推送以保护存量数据")
+            return
 
     try:
         resp = requests.post(


### PR DESCRIPTION
## 修复：查询线上 token 失败时中止推送，防止存量数据丢失

### 问题背景

`push_sso_to_api` 函数在推送新 token 前，会先通过 GET 请求查询线上已有的 token 列表，然后将新旧 token 合并去重后整体推送。

此前的逻辑中，当 GET 请求失败（HTTP 非 200）或抛出异常时，函数仅打印一条 `[Warn]` 日志，随后继续用**仅包含本次新 token** 的列表执行 POST 推送。这会导致线上已有的 token 被覆盖丢失。

### 修复方案

当查询线上 token 失败时，将日志级别从 `[Warn]` 提升为 `[Error]`，并立即 `return` 中止推送流程，避免在信息不完整的情况下覆写线上数据。

### 改动点

- **HTTP 请求失败**（状态码非 200）：打印错误日志后直接返回，不再继续推送
- **请求异常**（网络超时、连接错误等）：打印错误日志后直接返回，不再继续推送

### 影响范围

仅涉及 `DrissionPage_example.py` 中的 `push_sso_to_api` 函数，改动 4 行，不影响其他逻辑。