### PR TITLE
feat: 支持 Cloudflare Worker 临时邮箱 (freemail) 注册

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,11 +1,27 @@
 {
+    "_comment": "Grok 账号批量注册工具配置文件",
+
     "run": {
+        "_comment": "注册轮数，0 为无限循环，可通过 --count 命令行参数覆盖",
         "count": 10
     },
+
+    "_comment_mail_provider": "邮箱提供商: 'cloudflare' (推荐，自建 CF Worker 临时邮箱) 或 'duckmail' (默认，使用 duckmail.sbs)",
+    "mail_provider": "cloudflare",
+
+    "_comment_duckmail": "DuckMail 配置 (mail_provider 为 duckmail 时生效)",
     "duckmail_api_base": "https://api.duckmail.sbs",
     "duckmail_bearer": "<your_duckmail_bearer_token>",
+
+    "_comment_cf": "Cloudflare Worker 临时邮箱配置 (基于 https://github.com/idinging/freemail 部署, mail_provider 为 cloudflare 时生效)",
+    "cf_mail_api_base": "https://your-cf-worker.example.com",
+    "cf_mail_token": "<your_cf_mail_bearer_token>",
+
+    "_comment_proxy": "proxy: 邮箱 API 请求代理 (可选); browser_proxy: 浏览器代理，无头服务器需翻墙时填写 (可选)",
     "proxy": "",
     "browser_proxy": "",
+
+    "_comment_api": "grok2api 号池推送配置: endpoint 留空则跳过推送; append 为 true 时合并线上已有 token",
     "api": {
         "endpoint": "",
         "token": "",

--- a/email_register.py
+++ b/email_register.py
@@ -20,7 +20,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 # ============================================================
-# DuckMail 配置（从 config.json 加载）
+# 邮箱配置（从 config.json 加载）
 # ============================================================
 
 _config_path = Path(__file__).parent / "config.json"
@@ -29,9 +29,17 @@ if _config_path.exists():
     with _config_path.open("r", encoding="utf-8") as _f:
         _conf = json.load(_f)
 
+# 邮箱提供商: "duckmail" (默认) 或 "cloudflare"
+MAIL_PROVIDER = str(_conf.get("mail_provider", "duckmail")).strip().lower()
+
+# DuckMail 配置
 DUCKMAIL_API_BASE = str(_conf.get("duckmail_api_base", "https://api.duckmail.sbs"))
 DUCKMAIL_BEARER = str(_conf.get("duckmail_bearer", ""))
 PROXY = str(_conf.get("proxy", ""))
+
+# Cloudflare Worker 临时邮箱配置
+CF_MAIL_API_BASE = str(_conf.get("cf_mail_api_base", "")).rstrip("/")
+CF_MAIL_TOKEN = str(_conf.get("cf_mail_token", ""))
 
 # ============================================================
 # 适配层：为 DrissionPage_example.py 提供简单接口
@@ -42,25 +50,39 @@ _temp_email_cache: Dict[str, str] = {}
 
 def get_email_and_token() -> Tuple[Optional[str], Optional[str]]:
     """
-    创建 DuckMail 临时邮箱并返回 (email, mail_token)。
+    创建临时邮箱并返回 (email, mail_token)。
     供 DrissionPage_example.py 调用。
+    根据 mail_provider 配置自动选择 DuckMail 或 Cloudflare Worker。
     """
-    email, _password, mail_token = create_temp_email()
-    if email and mail_token:
-        _temp_email_cache[email] = mail_token
-        return email, mail_token
-    return None, None
+    if MAIL_PROVIDER == "cloudflare":
+        email = create_temp_email_cf()
+        if email:
+            # CF 模式下用邮箱地址本身作为 "token" (查询邮件时使用)
+            _temp_email_cache[email] = email
+            return email, email
+        return None, None
+    else:
+        email, _password, mail_token = create_temp_email()
+        if email and mail_token:
+            _temp_email_cache[email] = mail_token
+            return email, mail_token
+        return None, None
 
 
 def get_oai_code(dev_token: str, email: str, timeout: int = 30) -> Optional[str]:
     """
-    轮询 DuckMail 获取 OTP 验证码。
+    轮询获取 OTP 验证码。
     供 DrissionPage_example.py 调用。
+    根据 mail_provider 配置自动选择 DuckMail 或 Cloudflare Worker。
 
     Returns:
         验证码字符串（去除连字符，如 "MM0SF3"）或 None
     """
-    code = wait_for_verification_code(mail_token=dev_token, timeout=timeout)
+    if MAIL_PROVIDER == "cloudflare":
+        # CF 模式下 dev_token 实际是邮箱地址
+        code = wait_for_verification_code_cf(email_address=dev_token, timeout=timeout)
+    else:
+        code = wait_for_verification_code(mail_token=dev_token, timeout=timeout)
     if code:
         code = code.replace("-", "")
     return code
@@ -263,4 +285,130 @@ def extract_verification_code(content: str) -> Optional[str]:
         if code != "177010":
             return code
 
+    return None
+
+
+# ============================================================
+# Cloudflare Worker 临时邮箱 (基于 https://github.com/idinging/freemail)
+# ============================================================
+
+def _create_cf_mail_session():
+    """创建 Cloudflare Worker 请求会话（带 Bearer Token）"""
+    if curl_requests:
+        session = curl_requests.Session()
+        session.headers.update({
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {CF_MAIL_TOKEN}",
+        })
+        if PROXY:
+            session.proxies = {"http": PROXY, "https": PROXY}
+        return session, True
+
+    # fallback to requests
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    s = requests.Session()
+    retry = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    adapter = HTTPAdapter(max_retries=retry)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    s.headers.update({
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        "Accept": "application/json",
+        "Authorization": f"Bearer {CF_MAIL_TOKEN}",
+    })
+    if PROXY:
+        s.proxies = {"http": PROXY, "https": PROXY}
+    return s, False
+
+
+def create_temp_email_cf() -> Optional[str]:
+    """通过 Cloudflare Worker 创建临时邮箱，返回 email 地址"""
+    if not CF_MAIL_API_BASE or not CF_MAIL_TOKEN:
+        raise Exception("cf_mail_api_base 或 cf_mail_token 未设置")
+
+    session, use_cffi = _create_cf_mail_session()
+    try:
+        res = _do_request(session, use_cffi, "get",
+                          f"{CF_MAIL_API_BASE}/api/generate",
+                          timeout=15)
+        if res.status_code == 200:
+            data = res.json()
+            email = data.get("email")
+            if email:
+                print(f"[*] CF Worker 临时邮箱创建成功: {email}")
+                return email
+        raise Exception(f"创建邮箱失败: {res.status_code} - {res.text[:200]}")
+    except Exception as e:
+        raise Exception(f"CF Worker 创建邮箱失败: {e}")
+
+
+def fetch_emails_cf(email_address: str) -> List[Dict[str, Any]]:
+    """从 Cloudflare Worker 获取邮件列表"""
+    try:
+        session, use_cffi = _create_cf_mail_session()
+        res = _do_request(session, use_cffi, "get",
+                          f"{CF_MAIL_API_BASE}/api/emails",
+                          params={"mailbox": email_address},
+                          timeout=15)
+        if res.status_code == 200:
+            return res.json()
+    except Exception:
+        pass
+    return []
+
+
+def fetch_email_detail_cf(email_id) -> Optional[Dict]:
+    """获取 Cloudflare Worker 单封邮件详情"""
+    try:
+        session, use_cffi = _create_cf_mail_session()
+        res = _do_request(session, use_cffi, "get",
+                          f"{CF_MAIL_API_BASE}/api/email/{email_id}",
+                          timeout=15)
+        if res.status_code == 200:
+            return res.json()
+    except Exception:
+        pass
+    return None
+
+
+def wait_for_verification_code_cf(email_address: str, timeout: int = 120) -> Optional[str]:
+    """轮询 Cloudflare Worker 等待验证码邮件"""
+    print(f"[*] CF Worker 等待验证码邮件 ({email_address}, 最多 {timeout}s)...")
+    start = time.time()
+
+    while time.time() - start < timeout:
+        messages = fetch_emails_cf(email_address)
+        if messages and len(messages) > 0:
+            for msg in messages:
+                if not isinstance(msg, dict):
+                    continue
+                # CF Worker 可能已自动提取 verification_code
+                code = msg.get("verification_code")
+                if code:
+                    print(f"[*] CF Worker 提取到验证码: {code}")
+                    return str(code)
+                # fallback: 获取邮件详情并解析
+                msg_id = msg.get("id")
+                if msg_id:
+                    detail = fetch_email_detail_cf(msg_id)
+                    if detail:
+                        content = (
+                            detail.get("content")
+                            or detail.get("html_content")
+                            or detail.get("text")
+                            or detail.get("html")
+                            or ""
+                        )
+                        code = extract_verification_code(content)
+                        if code:
+                            print(f"[*] CF Worker 从邮件详情提取到验证码: {code}")
+                            return code
+
+        elapsed = int(time.time() - start)
+        print(f"[*] CF Worker 等待中... ({elapsed}s/{timeout}s)")
+        time.sleep(3)
+
+    print(f"[*] CF Worker 等待验证码超时 ({timeout}s)")
     return None

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,14 @@
 # Grok 账号批量注册工具
 
-基于 [DrissionPage](https://github.com/g1879/DrissionPage) 的 Grok (x.ai) 账号自动注册脚本，使用 [DuckMail](https://duckmail.sbs) 临时邮箱接收验证码，通过 Chrome 扩展修复 CDP `MouseEvent.screenX/screenY` 缺陷绕过 Cloudflare Turnstile。
+基于 [DrissionPage](https://github.com/g1879/DrissionPage) 的 Grok (x.ai) 账号自动注册脚本，支持 [Cloudflare Worker 临时邮箱 (freemail)](https://github.com/idinging/freemail) 和 [DuckMail](https://duckmail.sbs) 两种邮箱服务接收验证码，通过 Chrome 扩展修复 CDP `MouseEvent.screenX/screenY` 缺陷绕过 Cloudflare Turnstile。
 
 注册完成后自动推送 SSO token 到 [grok2api](https://github.com/chenyme/grok2api) 号池。
 
 ## 特性
 
-- DuckMail 临时邮箱（`curl_cffi` TLS 指纹伪装）
+- **双邮箱提供商支持**：Cloudflare Worker 临时邮箱 / DuckMail，通过配置一键切换
 - Cloudflare Turnstile 自动绕过（Chrome 扩展 patch `MouseEvent.screenX/screenY`）
+- `curl_cffi` TLS 指纹伪装
 - 无头服务器支持（Xvfb 虚拟显示器，自动检测 Linux 环境）
 - 中英文界面自动适配
 - 自动推送 SSO token 到 grok2api（支持 append 合并模式）
@@ -18,7 +19,9 @@
 
 - Python 3.10+
 - Chromium 或 Chrome 浏览器
-- [DuckMail](https://duckmail.sbs) 账号（用于创建临时邮箱）
+- 临时邮箱服务（二选一）：
+  - [Cloudflare Worker 临时邮箱 (freemail)](https://github.com/idinging/freemail)（推荐，自建部署）
+  - [DuckMail](https://duckmail.sbs) 账号
 - 可选：[grok2api](https://github.com/chenyme/grok2api) 实例（用于自动导入 SSO token）
 
 ---
@@ -46,11 +49,32 @@ pip install playwright && python -m playwright install chromium && python -m pla
 cp config.example.json config.json
 ```
 
-编辑 `config.json`：
+编辑 `config.json`，根据使用的邮箱服务选择对应配置：
+
+### 方式一：Cloudflare Worker 临时邮箱（推荐）
 
 ```json
 {
     "run": { "count": 10 },
+    "mail_provider": "cloudflare",
+    "cf_mail_api_base": "https://your-cf-worker.example.com",
+    "cf_mail_token": "<your_cf_mail_bearer_token>",
+    "proxy": "",
+    "browser_proxy": "",
+    "api": {
+        "endpoint": "",
+        "token": "",
+        "append": true
+    }
+}
+```
+
+### 方式二：DuckMail 临时邮箱
+
+```json
+{
+    "run": { "count": 10 },
+    "mail_provider": "duckmail",
     "duckmail_api_base": "https://api.duckmail.sbs",
     "duckmail_bearer": "<your_duckmail_bearer_token>",
     "proxy": "",
@@ -63,14 +87,19 @@ cp config.example.json config.json
 }
 ```
 
+> **提示**：`mail_provider` 不填或缺省时默认为 `"duckmail"`，兼容旧版配置。
+
 ### 字段说明
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
 | `run.count` | int | 注册轮数，`0` 为无限循环，可通过 `--count` 覆盖 |
+| `mail_provider` | string | 邮箱提供商：`"cloudflare"` 或 `"duckmail"`（默认） |
+| `cf_mail_api_base` | string | Cloudflare Worker 邮箱服务 API 地址 |
+| `cf_mail_token` | string | Cloudflare Worker 邮箱服务 Bearer Token |
 | `duckmail_api_base` | string | DuckMail API 地址，默认 `https://api.duckmail.sbs` |
 | `duckmail_bearer` | string | DuckMail Bearer Token（[获取方式](#获取-duckmail-bearer-token)） |
-| `proxy` | string | DuckMail API 请求代理（可选） |
+| `proxy` | string | 邮箱 API 请求代理（可选） |
 | `browser_proxy` | string | 浏览器代理，无头服务器需翻墙时填写（可选） |
 | `api.endpoint` | string | grok2api 管理接口地址，留空跳过推送 |
 | `api.token` | string | grok2api 的 `app_key` |
@@ -78,13 +107,29 @@ cp config.example.json config.json
 
 ---
 
-## 获取 DuckMail Bearer Token
+## 邮箱服务配置
+
+### Cloudflare Worker 临时邮箱 (freemail)
+
+使用 [freemail](https://github.com/idinging/freemail) 项目在 Cloudflare 上自建临时邮箱服务。部署方法参见 freemail 项目文档。
+
+该服务提供以下 API：
+- `GET /api/generate` — 自动创建临时邮箱，返回邮箱地址
+- `GET /api/emails?mailbox=<address>` — 获取指定邮箱的邮件列表
+- `GET /api/email/<id>` — 获取单封邮件详情
+
+配置项：
+1. 将 `mail_provider` 设为 `"cloudflare"`
+2. 填写 `cf_mail_api_base`（Worker 部署地址）
+3. 填写 `cf_mail_token`（Bearer Token）
+
+### 获取 DuckMail Bearer Token
 
 1. 打开 [duckmail.sbs](https://duckmail.sbs) 并注册登录
 2. 打开浏览器开发者工具 (F12) → Network
 3. 刷新页面，找到任意发往 `api.duckmail.sbs` 的请求
 4. 复制请求头中 `Authorization: Bearer <token>` 里的 token
-5. 填入 `config.json` 的 `duckmail_bearer` 字段
+5. 将 `mail_provider` 设为 `"duckmail"`，填入 `duckmail_bearer` 字段
 
 ---
 
@@ -121,8 +166,8 @@ logs/
 ## 文件结构
 
 ```
-├── DrissionPage_example.py     # 主脚本
-├── email_register.py           # DuckMail 临时邮箱封装
+├── DrissionPage_example.py     # 主脚本（浏览器自动化）
+├── email_register.py           # 邮箱服务封装（支持 Cloudflare Worker / DuckMail）
 ├── config.json                 # 配置文件（不入库）
 ├── config.example.json         # 配置模板
 ├── requirements.txt            # Python 依赖
@@ -147,4 +192,5 @@ logs/
 
 - [kevinr229/grok-maintainer](https://github.com/kevinr229/grok-maintainer) — 原始项目
 - [grok2api](https://github.com/chenyme/grok2api) — Grok API 代理
+- [freemail](https://github.com/idinging/freemail) — Cloudflare Worker 临时邮箱服务
 - [DuckMail](https://duckmail.sbs) — 临时邮箱服务


### PR DESCRIPTION
- 新增 mail_provider 配置项, 支持 cloudflare / duckmail 切换
- 新增 CF Worker 邮箱函数: 创建邮箱、获取邮件、轮询验证码
- 保持 get_email_and_token / get_oai_code 接口不变
- 更新 config.example.json 添加详细注释
- 更新 readme.md 文档说明双邮箱提供商用法
CF临时邮箱服务：
https://github.com/idinging/freemail